### PR TITLE
Specify custom refmap name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,7 @@ processResources {
 
 mixin {
     // MixinGradle Settings
+    add sourceSets.main, "hugestructureblocks.refmap.json"
     config 'hugestructureblocks.mixins.json'
 }
 

--- a/src/main/resources/hugestructureblocks.mixins.json
+++ b/src/main/resources/hugestructureblocks.mixins.json
@@ -15,5 +15,6 @@
   ],
   "injectors": {
     "defaultRequire": 1
-  }
+  },
+  "refmap": "hugestructureblocks.refmap.json"
 }


### PR DESCRIPTION
The default mixin refmap name when not configured is `mixin.refmap.json`.
If there are two mods that both make the mistake of not overriding this default name, only one of the refmaps is loaded and the other mod breaks due to it's mixins not being remapped.

In this case it was dye depot that also had this mistake, I fixed it there, but you should do so too in order to prevent this issue with other mods.

Make sure to run `clean build`, as there are some gradle bugs with mixin not adding the new refmap otherwise